### PR TITLE
Fixed: compact method return and types

### DIFF
--- a/lib/compact/index.js
+++ b/lib/compact/index.js
@@ -1,8 +1,7 @@
 export default function compact(arr) {
-  return arr && Array.isArray(arr) ?
-    arr.filter(function(i) {
-      return i;
-    })
-    :
-    arr;
+  return arr && Array.isArray(arr)
+    ? arr.filter(function(i) {
+        return i
+      })
+    : []
 }

--- a/lib/compact/index.js.flow
+++ b/lib/compact/index.js.flow
@@ -1,2 +1,2 @@
 // @flow
-declare module.exports: (arr: Array<any>) => Array<any>
+declare module.exports: (arr: Array<mixed>) => Array<mixed>

--- a/lib/compact/index.js.flow
+++ b/lib/compact/index.js.flow
@@ -1,2 +1,2 @@
 // @flow
-declare module.exports: (arr: Array<mixed>) => Array<mixed>
+declare module.exports: (arr: Array<mixed>) => Array<$NonMaybeType<mixed>>


### PR DESCRIPTION
Now method returns empty array instead of argument itself.

Do not understand, how to specify in flow, that resulting array contain only truthy values. Could somebody help me with it?