### PR TITLE
New methods: mapAccum (290 B), mapAccumRight (298 B)

### DIFF
--- a/lib/mapAccum/index.js
+++ b/lib/mapAccum/index.js
@@ -1,0 +1,11 @@
+import curryN from '../curryN'
+
+export default curryN(3, function mapAccum(cb, init, arr) {
+  return arr.reduce(
+    function(tuple, cur) {
+      var res = cb(tuple[0], cur)
+      return [res[0], tuple[1].concat([res[1]])]
+    },
+    [init, []]
+  )
+})

--- a/lib/mapAccum/mapAccum.test.js
+++ b/lib/mapAccum/mapAccum.test.js
@@ -1,0 +1,13 @@
+var mapAccum = require('.')
+
+var digits = ['1', '2', '3', '4']
+var appender = (a, b) => [a + b, a + b]
+var res = mapAccum(appender, 0, digits)
+
+test('returns result of reducer as 1st tuple element', () => {
+  expect(res[0]).toBe('01234')
+})
+
+test('returns array of accums as 2st tuple element', () => {
+  expect(res[1]).toEqual(['01', '012', '0123', '01234'])
+})

--- a/lib/mapAccumRight/index.js
+++ b/lib/mapAccumRight/index.js
@@ -1,0 +1,11 @@
+import curryN from '../curryN'
+
+export default curryN(3, function mapAccumRight(cb, init, arr) {
+  return arr.reduceRight(
+    function(tuple, cur) {
+      var res = cb(cur, tuple[1])
+      return [[res[0]].concat(tuple[0]), res[1]]
+    },
+    [[], init]
+  )
+})

--- a/lib/mapAccumRight/mapAccumRight.test.js
+++ b/lib/mapAccumRight/mapAccumRight.test.js
@@ -1,0 +1,13 @@
+var mapAccumRight = require('.')
+
+var digits = ['1', '2', '3', '4']
+var append = (a, b) => [a + b, a + b]
+var res = mapAccumRight(append, 5, digits)
+
+test('returns accums array as 1st tuple element', () => {
+  expect(res[0]).toEqual(['12345', '2345', '345', '45'])
+})
+
+test('returns accum as 2st tuple element', () => {
+  expect(res[1]).toEqual('12345')
+})


### PR DESCRIPTION
[`R.mapAccum`](http://ramdajs.com/docs/#mapAccum) and [`R.mapAccumRight`](http://ramdajs.com/docs/#mapAccumRight)
review cc/@Beraliv @BabkinAleksandr